### PR TITLE
Include plotNFT rewards in get_farmed_amount

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -4115,9 +4115,6 @@ class WalletRpcApi:
             if record.wallet_id not in self.service.wallet_state_manager.wallets:
                 continue
             if record.type == TransactionType.COINBASE_REWARD.value:
-                if self.service.wallet_state_manager.wallets[record.wallet_id].type() == WalletType.POOLING_WALLET:
-                    # Don't add pool rewards for pool wallets.
-                    continue
                 pool_reward_amount += record.amount
             height = record.height_farmed(self.service.constants.GENESIS_CHALLENGE)
             # .get_farming_rewards() above queries for only confirmed records.  This


### PR DESCRIPTION
### Purpose:

`chia get farm summary` currently only returns values for OG plots.
Since the majority of people have long since switched to plotNFT plots, I'm not sure why pooling wallets are being excluded from this calculation.

### Current Behavior:

`chia rpc wallet get_farmed_amount`

```
{                                                                                    "blocks_won": 114,
  "farmed_amount": 96752754128478,                                                   "farmer_reward_amount": 28500000000000,
  "fee_amount": 2754128478,                                                          "last_height_farmed": 3810216,
  "last_time_farmed": 1686871581,                                                    "pool_reward_amount": 68250000000000,
  "success": true                                                                  }
```

`chia farm summary`
```
Farming status: Farming
Total chia farmed: 96.752754128478
User transaction fees: 0.002754128478
Block rewards: 96.75                                                               Last height farmed: 3810216
...
```

### New Behavior:

`chia rpc wallet get_farmed_amount`
```
{
  "blocks_won": 114,
  "farmed_amount": 284002754128478,
  "farmer_reward_amount": 28500000000000,
  "fee_amount": 2754128478,                                                          "last_height_farmed": 6609397,                                                     "last_time_farmed": 1739076254,
  "pool_reward_amount": 255500000000000,
  "success": true
}
```

`chia farm summary`
```
Farming status: Farming
Total chia farmed: 284.002754128478                                                User transaction fees: 0.002754128478
Block rewards: 284.0
Last height farmed: 6609397
...
```

### Testing Notes:

I don't know if the changed calculations here would result in some negative behavior elsewhere, like in the GUI.
