### PR TITLE
feat: Add workflow to build and publish Linux Flatpak installers

### DIFF
--- a/.github/workflows/build-linux-flatpak.yml
+++ b/.github/workflows/build-linux-flatpak.yml
@@ -1,0 +1,242 @@
+name: 📦🚀 Build Installer - Linux Flatpak
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Tagged release testing scenario"
+        required: false
+        type: choice
+        default: ""
+        options:
+          - ""
+          - 9.9.9-b1
+          - 9.9.9-rc1
+          - 9.9.9
+  push:
+    paths-ignore:
+      - "**.md"
+    branches:
+      - "long_lived/**"
+      - main
+      - "release/**"
+  release:
+    types: [published]
+  pull_request:
+    paths-ignore:
+      - "**.md"
+    branches:
+      - "**"
+
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow_ref, github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  version:
+    uses: ./.github/workflows/reflow-version.yml
+    with:
+      release_type: ${{ inputs.release_type }}
+
+  build:
+    name: Build ${{ matrix.os.arch }} Flatpak
+    runs-on: ${{ matrix.os.runs-on }}
+    needs:
+      - version
+    container: chianetwork/ubuntu-22.04-builder:latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10"]
+        os:
+          - runs-on: ubuntu-latest
+            arch: amd64
+            arch-artifact-name: intel
+            madmax-suffix: "x86-64"
+            bladebit-suffix: "ubuntu-x86-64.tar.gz"
+          - runs-on: ubuntu-24.04-arm
+            arch: arm64
+            arch-artifact-name: arm
+            madmax-suffix: "arm64"
+            bladebit-suffix: "ubuntu-arm64.tar.gz"
+
+    env:
+      CHIA_INSTALLER_VERSION: ${{ needs.version.outputs.chia-installer-version }}
+      SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CHIA_BLOCKCHAIN: ${{ needs.version.outputs.chia-installer-version }}
+      POETRY_DYNAMIC_VERSIONING_OVERRIDE: "chia-blockchain=${{ needs.version.outputs.chia-installer-version }}"
+      TAG_TYPE: ${{ needs.version.outputs.tag-type }}
+
+    steps:
+      - uses: Chia-Network/actions/clean-workspace@main
+
+      - name: Add safe git directory
+        uses: Chia-Network/actions/git-mark-workspace-safe@main
+
+      - name: Checkout Code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - uses: Chia-Network/actions/git-ssh-to-https@main
+
+      - name: Cleanup any leftovers that exist from previous runs
+        run: bash build_scripts/clean-runner.sh || true
+
+      - name: Set Env
+        uses: Chia-Network/actions/setjobenv@main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node per .nvmrc in GUI
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: chia-blockchain-gui/.nvmrc
+
+      - name: Get latest madmax plotter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST_MADMAX=$(gh api repos/Chia-Network/chia-plotter-madmax/releases/latest --jq 'select(.prerelease == false) | .tag_name')
+          mkdir "$GITHUB_WORKSPACE"/madmax
+          gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot-*-${{ matrix.os.madmax-suffix }}' -O "$GITHUB_WORKSPACE"/madmax/chia_plot
+          gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot_k34-*-${{ matrix.os.madmax-suffix }}' -O "$GITHUB_WORKSPACE"/madmax/chia_plot_k34
+          chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot
+          chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot_k34
+
+      - name: Fetch bladebit versions
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Fetch the latest version of each type
+          LATEST_RELEASE=$(gh api repos/Chia-Network/bladebit/releases/latest --jq 'select(.prerelease == false) | .tag_name')
+          LATEST_BETA=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-beta[0-9]+$"))) | first | .tag_name')
+          LATEST_RC=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+$"))) | first | .tag_name')
+
+          # Compare the versions and choose the newest that matches the requirements
+          if [[ "$TAG_TYPE" == "beta" || -z "$TAG_TYPE" ]]; then
+            # For beta or dev builds (indicated by the absence of a tag), use the latest version available
+            LATEST_VERSION=$(printf "%s\n%s\n%s\n" "$LATEST_RELEASE" "$LATEST_BETA" "$LATEST_RC" | sed '/-/!s/$/_/' | sort -V | sed 's/_$//' | tail -n 1)
+          elif [[ "$TAG_TYPE" == "rc" ]]; then
+            # For RC builds, use the latest RC or full release if it's newer
+            LATEST_VERSION=$(printf "%s\n%s\n" "$LATEST_RELEASE" "$LATEST_RC" | sed '/-/!s/$/_/' | sort -V | sed 's/_$//' | tail -n 1)
+          else
+            # For full releases, use the latest full release
+            LATEST_VERSION="$LATEST_RELEASE"
+          fi
+          echo "LATEST_VERSION=$LATEST_VERSION" >> "$GITHUB_ENV"
+
+      - name: Get latest bladebit plotter
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Download and extract the chosen version
+          mkdir "$GITHUB_WORKSPACE"/bladebit
+          cd "$GITHUB_WORKSPACE"/bladebit
+          gh release download -R Chia-Network/bladebit "$LATEST_VERSION" -p 'bladebit*-${{ matrix.os.bladebit-suffix }}'
+          find . -maxdepth 1 -name '*.tar.gz' -print0 | xargs -0 -I{} bash -c 'tar -xzf {} && rm {}'
+          find . -maxdepth 1 -name 'bladebit*' -print0 | xargs -0 -I{} chmod +x {}
+          cd "$OLDPWD"
+
+      - uses: ./.github/actions/install
+        with:
+          python-version: ${{ matrix.python-version }}
+          development: true
+          constraints-file-artifact-name: constraints-file-${{ matrix.os.arch-artifact-name }}
+
+      - uses: chia-network/actions/activate-venv@main
+
+      - name: Prepare GUI cache
+        id: gui-ref
+        run: |
+          gui_ref=$(git submodule status chia-blockchain-gui | sed -e 's/^ //g' -e 's/ chia-blockchain-gui.*$//g')
+          echo "${gui_ref}"
+          echo "GUI_REF=${gui_ref}" >> "$GITHUB_OUTPUT"
+          echo "rm -rf ./chia-blockchain-gui"
+          rm -rf ./chia-blockchain-gui
+
+      - name: Cache GUI
+        uses: actions/cache@v4
+        id: cache-gui
+        with:
+          path: ./chia-blockchain-gui
+          key: ${{ runner.os }}-${{ matrix.os.arch }}-flatpak-chia-blockchain-gui-${{ steps.gui-ref.outputs.GUI_REF }}
+
+      - if: steps.cache-gui.outputs.cache-hit != 'true'
+        name: Build GUI
+        continue-on-error: false
+        run: |
+          cd ./build_scripts
+          bash build_linux_flatpak-gui.sh
+
+      - name: Build .flatpak package
+        run: |
+          ldd --version
+          cd ./build_scripts
+          bash build_linux_flatpak-installer.sh ${{ matrix.os.arch }}
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: chia-installers-linux-flatpak-${{ matrix.os.arch-artifact-name }}
+          path: ${{ github.workspace }}/build_scripts/final_installer/
+
+      - name: Remove working files to exclude from cache
+        run: |
+          rm -rf ./chia-blockchain-gui/packages/gui/daemon
+
+  publish:
+    name: 📦 Publish Installers
+    uses: ./.github/workflows/reflow-publish-installer.yml
+    with:
+      concurrency-name: flatpak
+      chia-installer-version: ${{ needs.version.outputs.chia-installer-version }}
+      chia-dev-version: ${{ needs.version.outputs.chia-dev-version }}
+      configuration: ${{ toJSON( matrix.configuration ) }}
+    secrets: inherit
+    needs:
+      - version
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration:
+          - python-version: ["3.10"]
+            os:
+              - matrix: flatpak
+                file-type:
+                  name: Flatpak
+                  extension: flatpak
+                glue-name: flatpak
+                artifact-platform-name: linux
+                file-arch-name:
+                  arm: arm64
+                  intel: amd64
+                file-suffix:
+                  arm: ""
+                  intel: ""
+                names:
+                  gui:
+                    file: chia-blockchain_{0}_{2}.flatpak
+                    dev-file: chia-blockchain_{1}_{2}.flatpak
+                    latest-dev-file: chia-blockchain_{2}_latest_dev.flatpak
+            mode:
+              - name: GUI
+                matrix: gui
+                glue-name: gui
+            arch:
+              - name: ARM64
+                matrix: arm
+                artifact-name: arm
+                glue-name: arm
+              - name: Intel
+                matrix: intel
+                artifact-name: intel
+                glue-name: intel

--- a/build_scripts/build_linux_flatpak-gui.sh
+++ b/build_scripts/build_linux_flatpak-gui.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+cd ../ || exit 1
+git submodule update --init chia-blockchain-gui
+
+cd ./chia-blockchain-gui || exit 1
+
+echo "npm build"
+npx lerna clean -y # Removes packages/*/node_modules
+npm ci
+# Audit fix does not currently work with Lerna. See https://github.com/lerna/lerna/issues/1663
+# npm audit fix
+npm run build
+LAST_EXIT_CODE=$?
+if [ "$LAST_EXIT_CODE" -ne 0 ]; then
+  echo >&2 "npm run build failed!"
+  exit $LAST_EXIT_CODE
+fi
+
+# Remove unused packages
+rm -rf node_modules
+
+# Other than `chia-blockchain-gui/package/gui`, all other packages are no longer necessary after build.
+# Since these unused packages make cache unnecessarily fat, here unused packages are removed.
+echo "Remove unused @chia-network packages to make cache slim"
+ls -l packages
+rm -rf packages/api
+rm -rf packages/api-react
+rm -rf packages/core
+rm -rf packages/icons
+rm -rf packages/wallets
+
+# Remove unused fat npm modules from the gui package
+cd ./packages/gui/node_modules || exit 1
+echo "Remove unused node_modules in the gui package to make cache slim more"
+rm -rf electron/dist # ~186MB
+rm -rf "@mui"        # ~71MB
+rm -rf typescript    # ~63MB
+
+# Remove `packages/gui/node_modules/@chia-network` because it causes an error on later `electron-packager` command
+rm -rf "@chia-network"

--- a/build_scripts/build_linux_flatpak-installer.sh
+++ b/build_scripts/build_linux_flatpak-installer.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+if [ ! "$1" ]; then
+  echo "This script requires either amd64 or arm64 as an argument"
+  exit 1
+elif [ "$1" = "amd64" ]; then
+  PLATFORM="amd64"
+  ELECTRON_BUILDER_ARCH="--x64"
+else
+  PLATFORM="arm64"
+  ELECTRON_BUILDER_ARCH="--arm64"
+fi
+export PLATFORM
+
+git status
+git submodule
+
+if [ ! "$CHIA_INSTALLER_VERSION" ]; then
+  echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."
+  CHIA_INSTALLER_VERSION="0.0.0"
+fi
+echo "Chia Installer Version is: $CHIA_INSTALLER_VERSION"
+export CHIA_INSTALLER_VERSION
+
+echo "Installing npm and electron packagers"
+cd npm_linux || exit 1
+npm ci
+NPM_PATH="$(pwd)/node_modules/.bin"
+cd .. || exit 1
+
+echo "Create dist/"
+rm -rf dist
+mkdir dist
+
+echo "Create executables with pyinstaller"
+SPEC_FILE=$(python -c 'import sys; from pathlib import Path; path = Path(sys.argv[1]); print(path.absolute().as_posix())' "pyinstaller.spec")
+pyinstaller --log-level=INFO "$SPEC_FILE"
+LAST_EXIT_CODE=$?
+if [ "$LAST_EXIT_CODE" -ne 0 ]; then
+  echo >&2 "pyinstaller failed!"
+  exit $LAST_EXIT_CODE
+fi
+
+echo "Building pip and NPM license directory"
+bash ./build_license_directory.sh
+
+cp -r dist/daemon ../chia-blockchain-gui/packages/gui
+
+cd ../chia-blockchain-gui/packages/gui || exit 1
+
+cp package.json package.json.orig
+jq --arg VER "$CHIA_INSTALLER_VERSION" '.version=$VER' package.json >temp.json && mv temp.json package.json
+
+echo "Install Flatpak tooling"
+sudo apt-get update -y
+sudo apt-get install -y flatpak flatpak-builder
+sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+sudo flatpak install -y --noninteractive flathub org.electronjs.Electron2.BaseApp//22.08
+sudo flatpak install -y --noninteractive flathub org.freedesktop.Sdk//22.08
+sudo flatpak install -y --noninteractive flathub org.freedesktop.Platform//22.08
+
+# electron-builder versions bundled with the GUI expect glob >= 10 for flatpak packaging
+npm install glob@latest
+
+echo "Building Linux Flatpak Electron app"
+PRODUCT_NAME="chia"
+"${NPM_PATH}/electron-builder" build --linux flatpak "${ELECTRON_BUILDER_ARCH}" \
+  --config.extraMetadata.name=chia-blockchain \
+  --config.productName="${PRODUCT_NAME}" --config.linux.desktop.Name="Chia Blockchain" \
+  --config ../../../build_scripts/electron-builder.json
+LAST_EXIT_CODE=$?
+find dist -maxdepth 1 -name 'linux*-unpacked' -print -exec ls -l {}/resources \;
+
+mv package.json.orig package.json
+
+if [ "$LAST_EXIT_CODE" -ne 0 ]; then
+  echo >&2 "electron-builder failed!"
+  exit $LAST_EXIT_CODE
+fi
+
+GUI_FLATPAK_NAME="chia-blockchain_${CHIA_INSTALLER_VERSION}_${PLATFORM}.flatpak"
+SOURCE_FLATPAK=$(find dist -maxdepth 1 -name '*.flatpak' -print -quit)
+if [ -z "$SOURCE_FLATPAK" ]; then
+  echo "Unable to locate generated flatpak package"
+  exit 1
+fi
+mv "$SOURCE_FLATPAK" "../../../build_scripts/dist/${GUI_FLATPAK_NAME}"
+cd ../../../build_scripts || exit 1
+
+echo "Create final installer"
+rm -rf final_installer
+mkdir final_installer
+
+mv "dist/${GUI_FLATPAK_NAME}" final_installer/
+
+ls -l final_installer/

--- a/build_scripts/electron-builder.json
+++ b/build_scripts/electron-builder.json
@@ -98,5 +98,10 @@
       "--rpm-tag=Requires(pre): findutils",
       "--before-install=../../../build_scripts/assets/rpm/before-install.sh"
     ]
+  },
+  "flatpak": {
+    "runtime": "org.freedesktop.platform",
+    "runtimeVersion": "22.08",
+    "baseVersion": "22.08"
   }
 }


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to build and publish Linux Flatpak installers for both amd64 and arm64 architectures. The workflow automates the process of building the GUI, packaging it as a Flatpak, and publishing the installer. It also includes caching to speed up subsequent builds.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
